### PR TITLE
exports frp

### DIFF
--- a/code_anaconda/run_step1.py
+++ b/code_anaconda/run_step1.py
@@ -140,3 +140,12 @@ def main(tag, firstday=None, lastday=None, vorimp='scipy', gt=3, buf0=False, ver
             except subprocess.CalledProcessError as err: 
                 print(f"\nERROR from 'step1_work': \n\n", err.stderr.decode(),)
                 raise
+        print("starting post %s: %s" % (dt.strftime('%Y-%m-%d'), datetime.datetime.now()))
+        cmd = ['psql',] + ['-f', (os.path.join(os.path.dirname(__file__), ('step1_post.sql' )))]
+        cmd += ['-v', ("tag=%s" % tag)] 
+        print(cmd)
+        try:
+            subprocess.run(cmd, check=True, stderr=PIPE)
+        except subprocess.CalledProcessError as err: 
+            print(f"\nERROR from 'step1_post': \n\n", err.stderr.decode(),)
+            raise

--- a/code_anaconda/run_step2.py
+++ b/code_anaconda/run_step2.py
@@ -168,7 +168,7 @@ def mkcmd_create_table_polygons(tag_tbl, tag_var, schema):
     return mkcmd_create_table_thematic(tag_tbl, tag_var, schema)
 
 def mkcmd_create_table_input(tag_tbl, tag_var, schema): 
-    return mkcmd_create_table_thematic(tag_tbl, tag_var, schema)
+    return mkcmd_create_table_continuous(tag_tbl, [tag_var], schema)
 
 def mkcmd_create_table_output(tag_tbls, fldnames, fldtypes, schema):
     tblname = 'out_' + '_'.join(tag_tbls)

--- a/code_anaconda/step1_post.sql
+++ b/code_anaconda/step1_post.sql
@@ -1,0 +1,22 @@
+-- schema name tag, prepended by af_
+\set myschema af_:tag
+-- to use in identifier in query.  without double quote it is converted to lower case
+\set ident_myschema '\"' :myschema '\"'
+-- to use as literal string
+\set quote_myschema '\'' :myschema '\''
+
+SET search_path TO :ident_myschema , public;
+SHOW search_path;
+
+
+\set ON_ERROR_STOP on
+
+-- set polyid of detection points
+WITH foo AS (
+	SELECT polyid, unnest(cleanids) cleanid
+	FROM work_div
+)
+UPDATE work_pnt p SET
+polyid = foo.polyid
+FROM foo
+WHERE p.cleanid = foo.cleanid;

--- a/code_anaconda/step1_prep_v7m.sql
+++ b/code_anaconda/step1_prep_v7m.sql
@@ -68,6 +68,7 @@ drop table if exists work_div;
 create table work_div (
 	polyid serial primary key ,
 	fireid integer,
+	cleanids integer[],
 	geom geometry,
 	acq_date_lst date,
 	area_sqkm double precision

--- a/code_anaconda/step1_work_v7m.sql
+++ b/code_anaconda/step1_work_v7m.sql
@@ -24,7 +24,11 @@ drop table if exists work_div_oned;
 create temporary table work_pnt_oned (like work_pnt excluding constraints);
 create temporary table work_lrg_oned (like work_lrg excluding constraints);
 create temporary table work_div_oned (like work_div excluding constraints);
-alter table work_div_oned drop column polyid;
+--alter table work_div_oned drop column polyid;
+-- convenient to have a temporaly serial id for work_div
+CREATE TEMPORARY SEQUENCE tmp_div_seq OWNED BY work_div_oned.polyid;
+ALTER TABLE work_div_oned ALTER COLUMN polyid SET DEFAULT nextval('tmp_div_seq');
+ALTER TABLE work_div_oned ALTER COLUMN polyid SET NOT NULL;
 
 -- select rawid, geom_pnt, lon, lat, scan, track, acq_date_lst, confidence, cleanid work_pnt from work_pnt   where acq_date_lst = :oned::date limit 1;
 
@@ -638,19 +642,38 @@ do language plpgsql $$ begin
 raise notice 'tool: step3.8 (lone detections) done, %', clock_timestamp();
 end $$;
 
-----------------------------------------------
--- STEP 3.9: subdivided polygons attributes --
-----------------------------------------------
+-----------------------------------------------------
+-- STEP 3.9: list of points in subdivided polygons --
+-----------------------------------------------------
 
--- update work_div_oned set
--- area_sqkm = st_area(geom::geography) / 1000000.;
+-- TODO see how costly this is, and make this to be option if it is
+CREATE INDEX work_div_gix ON work_div_oned USING gist( geom );
 
+WITH foo AS (
+	SELECT p.cleanid, d.polyid 
+	FROM work_pnt_oned AS p INNER JOIN work_div_oned AS d 
+	ON d.geom && p.geom_pnt
+	AND ST_Within( p.geom_pnt, d.geom )
+), bar AS (
+	SELECT polyid, array_agg(cleanid) cleanids
+	FROM foo
+	GROUP BY polyid
+)
+UPDATE work_div_oned SET cleanids = bar.cleanids
+FROM bar
+WHERE work_div_oned.polyid = bar.polyid;
 
+do language plpgsql $$ begin
+raise notice 'tool: step3.9 (points in polygon) done, %', clock_timestamp();
+end $$;
+
+---------------------
+-- STEP 3.10: push --
+---------------------
 
 -- push
-insert into work_div(fireid, geom, acq_date_lst, area_sqkm)
-select fireid, geom, acq_date_lst, area_sqkm from work_div_oned;
-
+insert into work_div(fireid, cleanids, geom, acq_date_lst, area_sqkm)
+select fireid, cleanids, geom, acq_date_lst, area_sqkm from work_div_oned;
 
 do language plpgsql $$ begin
 raise notice 'tool: step3 done, %', clock_timestamp();

--- a/work_generic/main_generic.ipynb
+++ b/work_generic/main_generic.ipynb
@@ -93,7 +93,8 @@
     "\n",
     "year_rst = 2017\n",
     "\n",
-    "filter_persistent_sources = True"
+    "filter_persistent_sources = True\n",
+    "export_frp = True"
    ]
   },
   {
@@ -428,7 +429,17 @@
     "            'variable_in': 'region_num',\n",
     "            'variable': 'regnum',\n",
     "        },\n",
-    "]"
+    "]\n",
+    "\n",
+    "if export_frp:\n",
+    "    rasters.append(\n",
+    "        {\n",
+    "            'tag': 'frp',\n",
+    "            'kind': 'input',\n",
+    "            'variable_in': 'frp',\n",
+    "            'variable': 'frp',\n",
+    "        }\n",
+    "    )"
    ]
   },
   {
@@ -839,7 +850,9 @@
    "outputs": [],
    "source": [
     "reload(run_step2)\n",
-    "run_step2.main(tag_af, rasters)"
+    "if export_frp:\n",
+    "    rasters.append\n",
+    "run_step2.main(tag_af, rasters, export_frp=export_frp)"
    ]
   },
   {
@@ -874,7 +887,19 @@
    "source": [
     "schema = 'af_' + tag_af\n",
     "tblname = 'out_{0}_{1}_{2}'.format(tag_lct, tag_vcf, tag_regnum)\n",
-    "flds = ('v_lct', 'f_lct', 'v_tree', 'v_herb', 'v_bare', 'v_regnum')"
+    "flds = ['v_lct', 'f_lct', 'v_tree', 'v_herb', 'v_bare', 'v_regnum']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if export_frp:\n",
+    "    shpname = shpname[:-4] + '_frp.shp'\n",
+    "    tblname = tblname + '_frp'\n",
+    "    flds.append('v_frp')"
    ]
   },
   {


### PR DESCRIPTION
The way i did was to make extra column in wor_pnt (cleaned set of detections) to have "polyid" field telling which subdivided polygon each the detection belongs to.  This was done by 

1. In step1, work, near the end of loop for a day, running query ST_Within() , to get list of cleanid (record id for work_pnt table) for each polygon.  Store this info as array of integers
2. After all the days are processed in step1, i run new "step1_post.sql" query, which unnest() the array to restore cleanid <-> polyid match as separate records, and use this table to fill the "polyid" field of cleanid.  So with this info i can query all the input record that fell within each subdivided polygonn
3. In step2, i made a mechanism to look up "input" value.  Remember, we have "thematic raster", "continous raster" and "vector" polygon these are seprate input files.  Now this new "input" (i realize it is not very good name...) will look up attribute for polygon from AF input, and right now I am using FRP.  But i should be able to look up other values.  I am simply caluculating arithmetic average, and attach the results as v_frp in the out_* table being exported.

I did cursory QA using Oregon test case, and seems to be working as i planned.

Concern is that this added operation of ST_Within() to map points to polygon, and filling the work_pnt table for polyid, may make entire tool slower than it is now. 

It would be better if this is on/off option, but right now step1 query is just one sql files, and it is not flexible.  I should rewrite code to use SQLAlchemy or something so that it would be more easier to modify part of it, like I am doing this time.   But for now, i'd think at least this branch would serve for users who wants FRP.  Will try merging this to master soon, once we find perfomance burden is acceptable.