### PR TITLE
specify versions of conda packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,14 +33,14 @@ RUN conda install -c conda-forge \
 	gdal=2.4 \
   "libgfortran-ng=7.2" \
 	python=3.7 \
-	jupyterlab \
-	ncurses \
-	pyproj \
-	beautifulsoup4 \
-	shapely \
-	psycopg2 \
+	jupyterlab=2.2.9 \
+	ncurses=6.2 \
+	pyproj=1.9.6 \
+	beautifulsoup4=4.9.3 \
+	shapely=1.6.4 \
+	psycopg2=2.8.4 \
 	matplotlib=2.2.5 \
-	basemap
+	basemap=1.2.1
 
 # verify that gdal is importable
 RUN /opt/conda/bin/python -c "from osgeo import gdal"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN conda install -c conda-forge \
 	beautifulsoup4 \
 	shapely \
 	psycopg2 \
-	matplotlib \
+	matplotlib=2.2.5 \
 	basemap
 
 # verify that gdal is importable


### PR DESCRIPTION
basemap was found not working when new image was built.  Turned out that basemap is not supported any more, and works with older version of matplotlib.  https://github.com/matplotlib/basemap/issues/494 .  So look at images that has working version of basemap, and identify matplotlib version in the image.  

I also fixed versions of all of the conda library (`conda list -e` tells versions of packages), and put them into Dockerfile