### PR TITLE
duplicate tropics first, then drop unneeded dates

### DIFF
--- a/work_nrt/work_nrt.py
+++ b/work_nrt/work_nrt.py
@@ -129,7 +129,9 @@ def sec6_process_activefire(first_day=None, last_day=None):
         dates0 = af_import.get_dates('af_' + tag_af, combined=True)
         dates = dates0[:]
         if first_day is not None:
-            dates = [_ for _ in dates if _ >= first_day]
+            # grab one more day for carry over
+            oneday = datetime.timedelta(days=1)
+            dates = [_ for _ in dates if _ >= first_day - oneday]
         if last_day is not None:
             dates = [_ for _ in dates if _ <= last_day]
         if not dates:


### PR DESCRIPTION
There was a bug in date-range specification feature, implemented for NRT application.  

The code was subsetting dates, and then duplicated record of tropics.  This doenst make sense, and i should duplicate records first, then subset by dates.